### PR TITLE
Fixing docker-compose.yml for docker-compose v3 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,10 +71,8 @@ services:
     hostname: tutorial
     container_name: fiware-tutorial
     depends_on:
-      keyrock:
-        condition: service_started
-      orion:
-        condition: service_started
+      - keyrock:
+      - orion:
     networks:
       default:
         ipv4_address: 172.18.1.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,8 @@ services:
     hostname: tutorial
     container_name: fiware-tutorial
     depends_on:
-      - keyrock:
-      - orion:
+      - keyrock
+      - orion
     networks:
       default:
         ipv4_address: 172.18.1.7


### PR DESCRIPTION
Fixing the error from docker-compose v3:
>services.tutorial.depends_on contains an invalid type, it should be an array